### PR TITLE
Enable reconnecting after a network disruption

### DIFF
--- a/Channel.qml
+++ b/Channel.qml
@@ -63,7 +63,7 @@ Item {
     }
 
     function _unsubscribe() {
-        if (_connected && subscribed) {
+        if (subscribed) {
             parent.unsubscribe(_oldName);
             _subscribed = false;
             _authenticated = false;
@@ -84,11 +84,10 @@ Item {
     }
 
     on_ConnectedChanged: {
-        if (active) {
+        if (active && _connected) {
             _subscribe();
         } else {
-            _subscribed = false;
-            _authenticated = false;
+            _unsubscribe();
         }
     }
 

--- a/Pusher.qml
+++ b/Pusher.qml
@@ -32,6 +32,11 @@ Item {
         socket.active = false;
     }
 
+    function reconnect() {
+        socket.active = false;
+        socket.active = true;
+    }
+
     function ping() {
         connection.ping();
     }

--- a/README.md
+++ b/README.md
@@ -120,6 +120,9 @@ Normally you should not need to call this function as it is called internally by
 
 Disconnects from Pusher.
 
+#### reconnect() :  function
+
+Reconnects to Pusher. Useful after a network disruption.
 
 #### authEndpoint : string ["/pusher/auth"]
 

--- a/qpm.json
+++ b/qpm.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/Cutehacks/qml-pusher.git"
   },
   "version": {
-    "label": "1.0.4"
+    "label": "1.1.0"
   },
   "dependencies": [
   ],


### PR DESCRIPTION
For example, when the wifi connection is lost and regained the WebSocket would
disconnect and not get reconnected.

Adds a reconnect() function to Pusher.

Additionally, the Channel needs to unsubscribe regardless of the connected
state to make sure the Pusher delists the Channel and that reauthentication
happens when reconnecting.

Bump to version 1.1.0 (due to new API).
